### PR TITLE
Make input text larger to prevent zooming on focus in mobile

### DIFF
--- a/kirakiratter.css
+++ b/kirakiratter.css
@@ -504,6 +504,16 @@ div.drawer__inner div:not(.navigation-bar) div:last-child div:last-child div:nth
   color: #fff;
 }
 
+.search__input, .autosuggest-textarea__textarea { 
+	font-size: 16px;
+}
+
+@media screen and (min-width: 1024px) {
+	.search__input, .autosuggest-textarea__textarea { 
+		font-size: inherit;
+	}
+}
+
 /* Settings Dropdown */
 .react-toggle-track {
   background: rgba(0, 0, 0, 0.6);

--- a/kirakiratter.css
+++ b/kirakiratter.css
@@ -510,7 +510,7 @@ div.drawer__inner div:not(.navigation-bar) div:last-child div:last-child div:nth
 
 @media screen and (min-width: 1024px) {
 	.search__input, .autosuggest-textarea__textarea { 
-		font-size: inherit;
+		font-size: 14px;
 	}
 }
 


### PR DESCRIPTION
Closes #7 
Tested in iOS Safari, not sure if other mobile browsers do auto-zoom on input focus