### PR TITLE
Make balloon tail border thickness more consistent

### DIFF
--- a/kirakiratter.css
+++ b/kirakiratter.css
@@ -257,7 +257,7 @@ body /* user */,
   box-shadow: 0 1px 1px rgba(0, 0, 0, 0.4);
 }
 
-/* status baloon tail */
+/* status balloon tail */
 
 .status::before,
 .notification::before {
@@ -284,7 +284,7 @@ body /* user */,
   border-style: solid;
   border-width: 10px;
   border-color: transparent #fcfce0 transparent transparent;
-  left: -20px;
+  left: -18px;
   top: 6px;
   transform: scaleY(0.66);
 }


### PR DESCRIPTION
Before: 
![chrome_2017-04-26_23-51-03](https://cloud.githubusercontent.com/assets/6811760/25467301/4c89b9b8-2adb-11e7-9f56-c798bb295196.png)

After:
![chrome_2017-04-26_23-51-25](https://cloud.githubusercontent.com/assets/6811760/25467303/50412fa0-2adb-11e7-9916-948e266cc8f3.png)

The fact that the status balloon tail borders were noticeably thinner than the rest of the balloon (because the `::before`/`::after` elements are vertically downscaled, as well as just some perceptual stuff because of the 45 degree angles) always bugged me, so a quick fix.