### PR TITLE
Adjust balloon tails on standalone pages

### DIFF
--- a/kirakiratter.css
+++ b/kirakiratter.css
@@ -908,16 +908,6 @@ button.icon-button.active i.fa-retweet {
   padding: 8px 8px 8px 15px;
 }
 
-.entry .status::after,
-.entry .notification::after {
-  left: -18px;
-}
-
-.entry .status::before,
-.entry .notification::before {
-  left: -10px;
-}
-
 .activity-stream .entry .pre-header {
   margin-bottom: 0;
   padding: 0 0 0 76px;


### PR DESCRIPTION
Gets rid of `::after` for balloon tails (which is no longer needed with the new SVG tails) and gets rid of the specific `::before` selector for the balloon tails on standalone pages, as it was actually moving the balloon tails too far to the right.

Before:
![chrome_2017-04-28_15-25-20](https://cloud.githubusercontent.com/assets/6811760/25544098/f3243a86-2c26-11e7-9437-ad5e2b9407bb.png)

After:
![chrome_2017-04-28_15-25-28](https://cloud.githubusercontent.com/assets/6811760/25544105/f7c0af8e-2c26-11e7-915b-b591fecd755a.png)