### PR TITLE
Fix lock/envelope icons for non-boostable statuses

### DIFF
--- a/kirakiratter.css
+++ b/kirakiratter.css
@@ -433,7 +433,7 @@ button.icon-button i.fa-retweet:hover {
 }
 
 .icon-button.disabled {
-  color: #8b6461;    
+  color: #9c7a78;    
 }
 
 .icon-button.disabled:hover {

--- a/kirakiratter.css
+++ b/kirakiratter.css
@@ -411,9 +411,7 @@ a span,
 .column-header,
 .column-link,
 .column-back-button,
-.column-back-button span,
-.icon-button.disabled i.fa-envelope,
-.icon-button.disabled i.fa-lock {
+.column-back-button span {
   color: #6a4643;
 }
 
@@ -433,6 +431,15 @@ a span,
 button.icon-button i.fa-retweet:hover {
   text-shadow: -1px -1px 0 #f5e33a, 1px -1px 0 #f5e33a, -1px 1px 0 #f5e33a, 1px 1px 0 #f5e33a;
 }
+
+.icon-button.disabled {
+  color: #8b6461;    
+}
+
+.icon-button.disabled:hover {
+  text-shadow: none;   
+}
+
 /* Katsu Drawer & Search */
 .navigation-bar {
   background: rgba(237, 42, 144, 0.6);


### PR DESCRIPTION
Before:
![chrome_2017-04-28_18-38-06](https://cloud.githubusercontent.com/assets/6811760/25549776/da1b1828-2c41-11e7-8365-d42403c1d842.png)
After:
![chrome_2017-04-28_18-37-33](https://cloud.githubusercontent.com/assets/6811760/25549778/dbd42ca4-2c41-11e7-94be-d998848b276f.png)

Yellow outline on hover removed. Also, they're the lighter brown now to make it clear that they're not clickable (in the original Mastodon, it's greyed out).