### PR TITLE
Fix and tweak styles for User Report panel

### DIFF
--- a/kirakiratter.css
+++ b/kirakiratter.css
@@ -606,12 +606,35 @@ div.drawer__inner div:not(.navigation-bar) div:last-child div:last-child div:nth
 
 /* User Report */
 
+.scrollable.report {
+  background: rgba(212, 220, 171, 0.5); /* transparentize(mix(#ecf5be, black, 90%), 0.5) */
+}
+
+.report__target {
+  color: #8e9956;
+}
+
+.report__target strong {
+  color: #8b6d5d;
+}
+
 .status-check-box .status__content {
   background: rgba(255, 255, 255, 0.7);
 }
 
 .status-check-box, .report__target {
   border-bottom: 1px solid rgba(0, 0, 0, 0.6);
+}
+
+.report__textarea {
+  color: #8b6d5d;
+  border-color: rgba(0, 0, 0, 0.3);
+}
+
+.report__textarea:active,
+.report__textarea:focus {
+  border-color: rgba(0, 0, 0, 0.5);
+  background: rgba(0, 0, 0, 0.05);
 }
 
 /* Drag and drop to upload */

--- a/kirakiratter.css
+++ b/kirakiratter.css
@@ -120,10 +120,6 @@ body /* user */,
   background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6Y2M9Imh0dHA6Ly9jcmVhdGl2ZWNvbW1vbnMub3JnL25zIyIgeG1sbnM6ZGM9Imh0dHA6Ly9wdXJsLm9yZy9kYy9lbGVtZW50cy8xLjEvIiBoZWlnaHQ9IjI4IiB3aWR0aD0iMjAiIHZpZXdCb3g9IjAgMCAyMCAyOCI+DQo8cmVjdCBoZWlnaHQ9IjI4IiB3aWR0aD0iMjAiIHk9IjAiIHg9IjAiIGZpbGw9IiNlNTZjYWMiLz4NCjxwYXRoIGQ9Im0wIDE0IDEwLTE0IDEwIDE0LTEwIDE0eiIgZmlsbD0iI2Q4NGE5ZCIvPg0KPC9zdmc+');
 }
 
-.column > .scrollable {
-  background: none;
-}
-
 .column-header,
 .column-icon,
 .column-back-button,
@@ -135,7 +131,7 @@ body /* user */,
 .column > .scrollable,
 .empty-column-indicator,
 .media-spoiler {
-  background: rgba(0, 0, 0, 0.1);
+  background: rgba(0, 0, 0, 0.05);
 }
 
 .account__header > div {


### PR DESCRIPTION
This patch fixes text colors, and make backgrounds lighter to:

- decrease contrast of the background pattern
- decrease contrast with status list (white background)
- improve readability of report comments (black text)

Before | After
------- | -----
![image](https://cloud.githubusercontent.com/assets/705555/25552154/506fe82e-2ccd-11e7-9da8-00ee2a8bf2dd.png) | ![image](https://cloud.githubusercontent.com/assets/705555/25552151/30318112-2ccd-11e7-8f78-ef2082b19125.png)
