### PR TITLE
Fix and more styling for column settings

### DIFF
--- a/kirakiratter.css
+++ b/kirakiratter.css
@@ -722,15 +722,27 @@ div.drawer__inner div:not(.navigation-bar) div:last-child div:last-child div:nth
 /* Settings Dropdown */
 
 .react-toggle-track {
-  background: rgba(0, 0, 0, 0.6);
+  background: rgba(0, 0, 0, 0.5);
 }
 
 .react-toggle:hover:not(.react-toggle--disabled) .react-toggle-track {
   background: rgba(0, 0, 0, 0.3);
 }
 
+.react-toggle-thumb {
+  border-color: rgba(0, 0, 0, 0.5);
+}
+
+.react-toggle--checked .react-toggle-track {
+  background: #9bc530;
+}
+
 .react-toggle--checked:hover:not(.react-toggle--disabled) .react-toggle-track {
-  background: #56a7e1;
+  background: #b4d75b;
+}
+
+.react-toggle--checked .react-toggle-thumb {
+  border-color: #9bc530;
 }
 
 .setting-text {

--- a/kirakiratter.css
+++ b/kirakiratter.css
@@ -186,6 +186,12 @@ body /* user */,
   border-color: transparent transparent #e3a4ad transparent;
 }
 
+.scrollable .status:first-child,
+.scrollable .notification:first-child,
+.account-timeline__header + .status {
+  margin-top: 6px;
+}
+
 .status,
 .notification,
 .onboarding-modal__pager::before,
@@ -462,6 +468,8 @@ a span, /* Toots */
 .media-spoiler,
 .nothing-here,
 .footer,
+.column-settings__section,
+.setting-toggle,
 .boost-modal__action-bar>div, /* Modals */
 .confirmation-modal__action-bar>div,
 .status.light .display-name span,
@@ -712,6 +720,7 @@ div.drawer__inner div:not(.navigation-bar) div:last-child div:last-child div:nth
 }
 
 /* Settings Dropdown */
+
 .react-toggle-track {
   background: rgba(0, 0, 0, 0.6);
 }
@@ -724,9 +733,18 @@ div.drawer__inner div:not(.navigation-bar) div:last-child div:last-child div:nth
   background: #56a7e1;
 }
 
+.setting-text {
+  color: #777;
+  outline: none;
+  border-color: rgba(0, 0, 0, 0.3);
+  padding: 7px 4px;
+}
+
 .setting-text:focus,
 .setting-text:active {
   color: #1a1a1a;
+  background: rgba(0, 0, 0, 0.05);
+  border-color: rgba(0, 0, 0, 0.5);
 }
 
 /* Profile Column */


### PR DESCRIPTION
And added margin-top to the first status.

Before | After
------- | ------
![image](https://cloud.githubusercontent.com/assets/705555/25555900/e21bdb84-2d2c-11e7-9c54-5896ff0e432f.png) | ![image](https://cloud.githubusercontent.com/assets/705555/25555904/fe319a84-2d2c-11e7-9271-e14f72904807.png)

Note that this patch uses Mastodon 1.3 classes. Most of those only don't work in 1.2, but I've replaced `.column-settings--outer` with `.column-settings__outer` so it is breaking change.