### PR TITLE
Made tabs bar labels easier to read

### DIFF
--- a/SCSS/kkt/components.scss
+++ b/SCSS/kkt/components.scss
@@ -1682,8 +1682,8 @@
   text-shadow: $yellow-border;
   text-decoration: none;
   text-align: center;
-  font-size: 14px;
-  font-weight: 500;
+  font-size: 16px;
+  font-weight: 700;
   transition: all 200ms linear;
 
   .fa {


### PR DESCRIPTION
Resolves #79.
Before:
<img width="1013" alt="screen shot 2017-08-17 at 6 30 30 pm" src="https://user-images.githubusercontent.com/6811760/29436590-3f2b8cc2-837a-11e7-8a20-d7f8f6a81e9c.png">
<img width="1013" alt="screen shot 2017-08-17 at 6 29 14 pm" src="https://user-images.githubusercontent.com/6811760/29436539-ff68b8da-8379-11e7-984e-fe11bf4ce65a.png">
After:
<img width="1013" alt="screen shot 2017-08-17 at 6 30 51 pm" src="https://user-images.githubusercontent.com/6811760/29436593-445c89d0-837a-11e7-9c40-acec71cf8c64.png">
<img width="1013" alt="screen shot 2017-08-17 at 6 26 55 pm" src="https://user-images.githubusercontent.com/6811760/29436468-b2428ea0-8379-11e7-97e0-37bb1e7baab5.png">