### PR TITLE
Change notifications icon color to pink

### DIFF
--- a/SCSS/kkt/components.scss
+++ b/SCSS/kkt/components.scss
@@ -1206,7 +1206,7 @@
   position: relative;
 
   .fa {
-    color: $brown-ui;
+    color: $pink-ui;
   }
 }
 


### PR DESCRIPTION
Resolves #81 and changes the icon for these two notification types (I think? Are there more?) from brown to pink, since that better reflects those icons once you actually press them.
<img width="319" alt="screen shot 2017-08-17 at 7 05 45 pm" src="https://user-images.githubusercontent.com/6811760/29437561-3fe98c22-837f-11e7-9105-ea2d6b47c379.png">
