### PR TITLE
Fix GIF indicator colors

### DIFF
--- a/SCSS/kkt/components.scss
+++ b/SCSS/kkt/components.scss
@@ -3890,8 +3890,8 @@ button.icon-button.active i.fa-retweet {
 .media-gallery__gifv__label {
   display: block;
   position: absolute;
-  color: $primary-text-color;
-  background: rgba($white, 0.4);
+  color: $white;
+  background: rgba($black, 0.4);
   bottom: 6px;
   left: 6px;
   padding: 2px 6px;


### PR DESCRIPTION
Resolves #83.

|Before|After|
|------|------|
|<img width="223" alt="screen shot 2017-08-17 at 7 15 28 pm" src="https://user-images.githubusercontent.com/6811760/29437744-864f658c-8380-11e7-98dd-a5fe18ea9bee.png">|<img width="221" alt="screen shot 2017-08-17 at 7 14 28 pm" src="https://user-images.githubusercontent.com/6811760/29437747-8be0af1a-8380-11e7-975c-fde5b5ee480b.png">|
